### PR TITLE
Reward experiments

### DIFF
--- a/Agents/FFNet.py
+++ b/Agents/FFNet.py
@@ -72,8 +72,8 @@ class OLBMReinforceTrainer:
         self.num_workers = num_workers  # Should refactor this to get direct from self.model?
         self.reward_mode = reward_mode
         self._time = str(time.time())
-        self.log_file = self._time + "_OLBM_REINFORCE_TRAINING_LOG.csv"
         self.model_name = self._time + "_" + self.model.name() + "_" + self.reward_mode
+        self.log_file = self.model_name + "_TRAINING_LOG.csv"
 
     def train_iteration(self, problem_generator_seed=1234):
         # Generate an OLBM problem:
@@ -170,7 +170,7 @@ class OLBMReinforceTrainer:
                 print(f"EPISODE {episode} - SCORE: {reward}")
                 print(f"Rolling average over last {len(rolling_avg)} episodes = {np.mean(rolling_avg)}")
                 with open(self.log_file, 'a+') as log:
-                    log.write(f"{episode}, {rolling_avg}\n")
+                    log.write(f"{episode}, {np.mean(rolling_avg)}\n")
             if episode % 10000 == 0:
                 # Save a snapshot of the model weights:
                 torch.save(self.model.state_dict(), f"./{self.model_name}.pth")

--- a/test_loop.py
+++ b/test_loop.py
@@ -6,11 +6,11 @@ from Agents.FFNet import LinearFFNet, OLBMReinforceTrainer
 import torch
 from tqdm import tqdm
 
-NUM_TRAINING_ITERATIONS = 240000
+NUM_TRAINING_ITERATIONS = 500000
 NUM_TESTS_TO_RUN = 5000
 NUM_TASKS = 10
 NUM_WORKERS = 60
-DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")  # Automatically set the device for computation
+DEVICE = "cpu"
 
 def main():
     # Load up the GMission Dataset:
@@ -42,7 +42,7 @@ def main():
     print("NOW TRAINING: LinearFFNet:")
     input_vector_size = NUM_TASKS * 2  # One entry for each edge, one entry for each value in bitmap
     model = LinearFFNet(input_vector_size, NUM_TASKS)
-    trainer = OLBMReinforceTrainer(model=model, num_tasks=NUM_TASKS, num_workers=NUM_WORKERS)
+    trainer = OLBMReinforceTrainer(model=model, num_tasks=NUM_TASKS, num_workers=NUM_WORKERS, reward_mode="FINAL_REWARD")
     trainer.train_N_iterations(NUM_TRAINING_ITERATIONS)  # This will take a while to run
 
     # TEST FFNET:


### PR DESCRIPTION
Added 3 types of reward to the FFNet

*  SARSA_REWARD is the kind of reward we were using before: essentially, "reward" is the "value added" by the action i.e. the value of adding an edge to the matching. Discounted reward is calculated by adding the reward at the current time-step to the discounted reward at all future time-steps
* FINAL_REWARD runs a matching problem through til the end, then calculates discounted reward backwards from the total matching value at the end
* TOTAL_REWARD calculates reward at each step in the matching, but calculates reward as the _sum_ of all the edges included in the matching at that step (as opposed to just the edge that was added at that step)

Not sure which of these is going to work better, but I put together a logging system so that we can keep track of things.